### PR TITLE
histogram: add TimeHistogram

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,19 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  check_features:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack check --each-feature
+
   test:
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}
     needs: [style]

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -13,12 +13,6 @@ use std::iter::once;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-/// Extension trait for [`prometheus_client::metrics::histogram::Histogram`].
-pub trait HistogramExt {
-    /// Returns a timer whose value will be recorded in this histogram.
-    fn start_timer(&self) -> HistogramTimer;
-}
-
 /// A faster, lock-free histogram for tracking time.
 #[derive(Debug)]
 pub struct TimeHistogram {
@@ -41,16 +35,6 @@ struct Inner {
     sum: AtomicU64,
     count: AtomicU64,
     buckets: Vec<(f64, AtomicU64)>,
-}
-
-impl HistogramExt for TimeHistogram {
-    fn start_timer(&self) -> HistogramTimer {
-        HistogramTimer {
-            histogram: self.clone(),
-            observed: false,
-            start: Instant::now(),
-        }
-    }
 }
 
 impl HistogramTimer {
@@ -112,6 +96,14 @@ impl TimeHistogram {
                     .map(|upper_bound| (upper_bound, AtomicU64::new(0)))
                     .collect(),
             }),
+        }
+    }
+
+    pub fn start_timer(&self) -> HistogramTimer {
+        HistogramTimer {
+            histogram: self.clone(),
+            observed: false,
+            start: Instant::now(),
         }
     }
 

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -111,7 +111,7 @@ impl TimeHistogram {
         self.observe_and_bucket(nanos);
     }
 
-    pub(crate) fn observe_and_bucket(&self, v: u64) -> Option<usize> {
+    fn observe_and_bucket(&self, v: u64) -> Option<usize> {
         self.inner.sum.fetch_add(v, Ordering::Relaxed);
         self.inner.count.fetch_add(1, Ordering::Relaxed);
 
@@ -131,7 +131,7 @@ impl TimeHistogram {
         }
     }
 
-    pub(crate) fn get(&self) -> (f64, u64, Vec<(f64, u64)>) {
+    fn get(&self) -> (f64, u64, Vec<(f64, u64)>) {
         let sum = seconds(self.inner.sum.load(Ordering::Relaxed));
         let count = self.inner.count.load(Ordering::Relaxed);
         let buckets = self

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -1,7 +1,17 @@
-//! Extensions for [`prometheus_client::metrics::histogram::Histogram`].
+//! A faster, lock-free histogram for tracking timing data.
+//!
+//! This is based on the implementation for [`prometheus_client::metrics::histogram::Histogram`],
+//! with several changes made to eliminate the need for locks.
 
-use prometheus_client::metrics::histogram::Histogram;
 use std::time::{Duration, Instant};
+
+use prometheus_client::encoding::text::{Encode, EncodeMetric, Encoder};
+use prometheus_client::metrics::exemplar::Exemplar;
+use prometheus_client::metrics::{MetricType, TypedMetric};
+use std::collections::HashMap;
+use std::iter::once;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 /// Extension trait for [`prometheus_client::metrics::histogram::Histogram`].
 pub trait HistogramExt {
@@ -9,7 +19,31 @@ pub trait HistogramExt {
     fn start_timer(&self) -> HistogramTimer;
 }
 
-impl HistogramExt for Histogram {
+/// A faster, lock-free histogram for tracking time.
+#[derive(Debug)]
+pub struct TimeHistogram {
+    inner: Arc<Inner>,
+}
+
+/// Timer to measure and record the duration of an event.
+///
+/// This timer can be stopped and observed at most once, either automatically
+/// (when it goes out of scope) or manually. Alternatively, it can be manually
+/// stopped and discarded in order to not record its value.
+pub struct HistogramTimer {
+    histogram: TimeHistogram,
+    observed: bool,
+    start: Instant,
+}
+
+#[derive(Debug)]
+struct Inner {
+    sum: AtomicU64,
+    count: AtomicU64,
+    buckets: Vec<(f64, AtomicU64)>,
+}
+
+impl HistogramExt for TimeHistogram {
     fn start_timer(&self) -> HistogramTimer {
         HistogramTimer {
             histogram: self.clone(),
@@ -19,23 +53,12 @@ impl HistogramExt for Histogram {
     }
 }
 
-/// Timer to measure and record the duration of an event.
-///
-/// This timer can be stopped and observed at most once, either automatically
-/// (when it goes out of scope) or manually. Alternatively, it can be manually
-/// stopped and discarded in order to not record its value.
-pub struct HistogramTimer {
-    histogram: Histogram,
-    observed: bool,
-    start: Instant,
-}
-
 impl HistogramTimer {
     /// Observe, record and return timer duration (in seconds).
     ///
     /// It observes and returns a floating-point number for seconds elapsed since
     /// the timer started, recording that value to the attached histogram.
-    pub fn stop_and_record(self) -> f64 {
+    pub fn stop_and_record(self) -> Duration {
         let mut timer = self;
         timer.observe(true)
     }
@@ -44,18 +67,20 @@ impl HistogramTimer {
     ///
     /// It returns a floating-point number of seconds elapsed since the timer started,
     /// without recording to any histogram.
-    pub fn stop_and_discard(self) -> f64 {
+    pub fn stop_and_discard(self) -> Duration {
         let mut timer = self;
         timer.observe(false)
     }
 
-    fn observe(&mut self, record: bool) -> f64 {
-        let v = duration_to_seconds(Instant::now().saturating_duration_since(self.start));
+    fn observe(&mut self, record: bool) -> Duration {
+        let elapsed = Instant::now().saturating_duration_since(self.start);
+
         self.observed = true;
         if record {
-            self.histogram.observe(v);
+            self.histogram.observe(elapsed.as_nanos() as u64);
         }
-        v
+
+        elapsed
     }
 }
 
@@ -67,8 +92,142 @@ impl Drop for HistogramTimer {
     }
 }
 
-#[inline]
-fn duration_to_seconds(d: Duration) -> f64 {
-    let nanos = f64::from(d.subsec_nanos()) / 1e9;
-    d.as_secs() as f64 + nanos
+impl Clone for TimeHistogram {
+    fn clone(&self) -> Self {
+        TimeHistogram {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl TimeHistogram {
+    pub fn new(buckets: impl Iterator<Item = f64>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                sum: Default::default(),
+                count: Default::default(),
+                buckets: buckets
+                    .into_iter()
+                    .chain(once(f64::MAX))
+                    .map(|upper_bound| (upper_bound, AtomicU64::new(0)))
+                    .collect(),
+            }),
+        }
+    }
+
+    pub fn observe(&self, nanos: u64) {
+        self.observe_and_bucket(nanos);
+    }
+
+    pub(crate) fn observe_and_bucket(&self, v: u64) -> Option<usize> {
+        self.inner.sum.fetch_add(v, Ordering::Relaxed);
+        self.inner.count.fetch_add(1, Ordering::Relaxed);
+
+        let first_bucket = self
+            .inner
+            .buckets
+            .iter()
+            .enumerate()
+            .find(|(_i, (upper_bound, _value))| upper_bound >= &(v as f64 * 1E-9));
+
+        match first_bucket {
+            Some((i, (_upper_bound, value))) => {
+                value.fetch_add(1, Ordering::Relaxed);
+                Some(i)
+            }
+            None => None,
+        }
+    }
+
+    pub(crate) fn get(&self) -> (f64, u64, Vec<(f64, u64)>) {
+        let sum = seconds(self.inner.sum.load(Ordering::Relaxed));
+        let count = self.inner.count.load(Ordering::Relaxed);
+        let buckets = self
+            .inner
+            .buckets
+            .iter()
+            .map(|(k, v)| (*k, v.load(Ordering::Relaxed)))
+            .collect();
+        (sum, count, buckets)
+    }
+}
+
+impl TypedMetric for TimeHistogram {
+    const TYPE: MetricType = MetricType::Histogram;
+}
+
+#[inline(always)]
+fn seconds(val: u64) -> f64 {
+    (val as f64) * 1E-9
+}
+
+fn encode_histogram_with_maybe_exemplars<S: Encode>(
+    sum: f64,
+    count: u64,
+    buckets: &[(f64, u64)],
+    exemplars: Option<&HashMap<usize, Exemplar<S, f64>>>,
+    mut encoder: Encoder,
+) -> Result<(), std::io::Error> {
+    encoder
+        .encode_suffix("sum")?
+        .no_bucket()?
+        .encode_value(sum)?
+        .no_exemplar()?;
+    encoder
+        .encode_suffix("count")?
+        .no_bucket()?
+        .encode_value(count)?
+        .no_exemplar()?;
+
+    let mut cummulative = 0;
+    for (i, (upper_bound, count)) in buckets.iter().enumerate() {
+        cummulative += count;
+        let mut bucket_encoder = encoder.encode_suffix("bucket")?;
+        let mut value_encoder = bucket_encoder.encode_bucket(*upper_bound)?;
+        let mut exemplar_encoder = value_encoder.encode_value(cummulative)?;
+
+        match exemplars.and_then(|es| es.get(&i)) {
+            Some(exemplar) => exemplar_encoder.encode_exemplar(exemplar)?,
+            None => exemplar_encoder.no_exemplar()?,
+        }
+    }
+
+    Ok(())
+}
+
+impl EncodeMetric for TimeHistogram {
+    fn encode(&self, encoder: Encoder) -> Result<(), std::io::Error> {
+        let (sum, count, buckets) = self.get();
+        // TODO: Would be better to use never type instead of `()`.
+        encode_histogram_with_maybe_exemplars::<()>(sum, count, &buckets, None, encoder)
+    }
+
+    fn metric_type(&self) -> MetricType {
+        Self::TYPE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus_client::metrics::histogram::exponential_buckets;
+    use std::time::Duration;
+
+    #[test]
+    fn histogram() {
+        let histogram = TimeHistogram::new(exponential_buckets(1.0, 2.0, 10));
+        histogram.observe(Duration::from_secs(1).as_nanos() as u64);
+        histogram.observe(Duration::from_secs_f64(1.5).as_nanos() as u64);
+        histogram.observe(Duration::from_secs_f64(2.5).as_nanos() as u64);
+        histogram.observe(Duration::from_secs_f64(8.5).as_nanos() as u64);
+        histogram.observe(Duration::from_secs_f64(0.5).as_nanos() as u64);
+
+        let (sum, count, buckets) = histogram.get();
+
+        assert_eq!(14., sum);
+        assert_eq!(5, count);
+        assert_eq!(2, buckets[0].1);
+        assert_eq!(1, buckets[1].1);
+        assert_eq!(1, buckets[4].1);
+    }
 }


### PR DESCRIPTION
This change pulls in the TimeHistogram from https://github.com/Noah-Kennedy/prometheus-client-utils.git, allowing us to get rid of tha crate, and changes the HistogramTimer to use that histogram instead of the one from the prometheus_client crate.

It also makes a minor change to CI, adding a new job which runs `cargo check` on each feature.