### PR TITLE
fix: make HistogramTimer must_use to avoid misuse

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -24,6 +24,7 @@ pub struct TimeHistogram {
 /// This timer can be stopped and observed at most once, either automatically
 /// (when it goes out of scope) or manually. Alternatively, it can be manually
 /// stopped and discarded in order to not record its value.
+#[must_use = "HistogramTimer measures on Drop so should assigned to named variable"]
 pub struct HistogramTimer {
     histogram: TimeHistogram,
     observed: bool,


### PR DESCRIPTION
HistogramTimer records the time on Drop, without `must_use` a user can create a timer and not assign causing it to immediately Drop and measure a very short interval.